### PR TITLE
chore: release  operator 0.1.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "klyshko-mp-spdz": "0.0.1",
-  "klyshko-operator": "0.0.1",
+  "klyshko-operator": "0.1.0",
   "klyshko-operator/charts/klyshko-operator": "0.0.1",
   "klyshko-provisioner": "0.0.1"
 }

--- a/klyshko-operator/CHANGELOG.md
+++ b/klyshko-operator/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.0](https://github.com/carbynestack/klyshko/compare/operator-v0.0.1...operator-v0.1.0) (2023-03-13)
+
+
+### Features
+
+* **mp-spdz/operator/operator-chart/provisioner:** initial commit for k8s operator based implementation ([b4da582](https://github.com/carbynestack/klyshko/commit/b4da58202091eefcea3782070587f094d9dabb83))


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.0](https://github.com/carbynestack/klyshko/compare/operator-v0.0.1...operator-v0.1.0) (2023-03-13)


### Features

* **mp-spdz/operator/operator-chart/provisioner:** initial commit for k8s operator based implementation ([b4da582](https://github.com/carbynestack/klyshko/commit/b4da58202091eefcea3782070587f094d9dabb83))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).