### PR TITLE
chore: release  operator-chart 0.1.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "klyshko-mp-spdz": "0.1.0",
   "klyshko-operator": "0.1.0",
-  "klyshko-operator/charts/klyshko-operator": "0.0.1",
+  "klyshko-operator/charts/klyshko-operator": "0.1.0",
   "klyshko-provisioner": "0.1.0"
 }

--- a/klyshko-operator/charts/klyshko-operator/CHANGELOG.md
+++ b/klyshko-operator/charts/klyshko-operator/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.0](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.0.1...operator-chart-v0.1.0) (2023-03-13)
+
+
+### Features
+
+* **mp-spdz/operator/operator-chart/provisioner:** initial commit for k8s operator based implementation ([b4da582](https://github.com/carbynestack/klyshko/commit/b4da58202091eefcea3782070587f094d9dabb83))

--- a/klyshko-operator/charts/klyshko-operator/Chart.yaml
+++ b/klyshko-operator/charts/klyshko-operator/Chart.yaml
@@ -1,12 +1,6 @@
-#
-# Copyright (c) 2022 - for information on the respective copyright owner
-# see the NOTICE file and/or the repository https://github.com/carbynestack/klyshko.
-#
-# SPDX-License-Identifier: Apache-2.0
-#
 apiVersion: v2
 name: klyshko-operator
 description: A Helm chart for the Carbyne Stack Klyshko Operator
 type: application
 version: 0.1.0
-appVersion: "0.1.0"
+appVersion: 0.1.0


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.0](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.0.1...operator-chart-v0.1.0) (2023-03-13)


### Features

* **mp-spdz/operator/operator-chart/provisioner:** initial commit for k8s operator based implementation ([b4da582](https://github.com/carbynestack/klyshko/commit/b4da58202091eefcea3782070587f094d9dabb83))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).