### PR TITLE
chore: release  operator 0.1.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "klyshko-mp-spdz": "0.1.4",
-  "klyshko-operator": "0.1.0",
+  "klyshko-operator": "0.1.1",
   "klyshko-operator/charts/klyshko-operator": "0.1.3",
   "klyshko-provisioner": "0.1.0"
 }

--- a/klyshko-operator/CHANGELOG.md
+++ b/klyshko-operator/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.1.1](https://github.com/carbynestack/klyshko/compare/operator-v0.1.0...operator-v0.1.1) (2023-03-15)
+
+
+### Bug Fixes
+
+* **mp-spdz/operator-chart:** empty commit to trigger publication of artifacts ([#30](https://github.com/carbynestack/klyshko/issues/30)) ([f9beb81](https://github.com/carbynestack/klyshko/commit/f9beb81703fe8a14f568437cd29b7362381ae402))
+* **mp-spdz/operator-chart:** trigger workflows ([#37](https://github.com/carbynestack/klyshko/issues/37)) ([1a754c3](https://github.com/carbynestack/klyshko/commit/1a754c336d4cef441b1cbcaeb4820d034c38b90e))
+* **mp-spdz/operator-chart:** trigger workflows ([#41](https://github.com/carbynestack/klyshko/issues/41)) ([bf8b9b0](https://github.com/carbynestack/klyshko/commit/bf8b9b0a51d85473d6bf785dfd0efab608124ccc))
+* **mp-spdz:** trigger workflow ([5ab6139](https://github.com/carbynestack/klyshko/commit/5ab6139349bc6349045128edde210f7d337de47d))
+* **operator-chart:** rename chart to make publication workflow work ([#47](https://github.com/carbynestack/klyshko/issues/47)) ([b529207](https://github.com/carbynestack/klyshko/commit/b5292070fda11633f8b61b972dce4882a6e7bef1))
+
 ## [0.1.0](https://github.com/carbynestack/klyshko/compare/operator-v0.0.1...operator-v0.1.0) (2023-03-13)
 
 


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.1](https://github.com/carbynestack/klyshko/compare/operator-v0.1.0...operator-v0.1.1) (2023-03-15)


### Bug Fixes

* **mp-spdz/operator-chart:** empty commit to trigger publication of artifacts ([#30](https://github.com/carbynestack/klyshko/issues/30)) ([f9beb81](https://github.com/carbynestack/klyshko/commit/f9beb81703fe8a14f568437cd29b7362381ae402))
* **mp-spdz/operator-chart:** trigger workflows ([#37](https://github.com/carbynestack/klyshko/issues/37)) ([1a754c3](https://github.com/carbynestack/klyshko/commit/1a754c336d4cef441b1cbcaeb4820d034c38b90e))
* **mp-spdz/operator-chart:** trigger workflows ([#41](https://github.com/carbynestack/klyshko/issues/41)) ([bf8b9b0](https://github.com/carbynestack/klyshko/commit/bf8b9b0a51d85473d6bf785dfd0efab608124ccc))
* **mp-spdz:** trigger workflow ([5ab6139](https://github.com/carbynestack/klyshko/commit/5ab6139349bc6349045128edde210f7d337de47d))
* **operator-chart:** rename chart to make publication workflow work ([#47](https://github.com/carbynestack/klyshko/issues/47)) ([b529207](https://github.com/carbynestack/klyshko/commit/b5292070fda11633f8b61b972dce4882a6e7bef1))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).