### PR TITLE
chore: release  operator-chart 0.1.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "klyshko-mp-spdz": "0.1.0",
   "klyshko-operator": "0.1.0",
-  "klyshko-operator/charts/klyshko-operator": "0.1.0",
+  "klyshko-operator/charts/klyshko-operator": "0.1.1",
   "klyshko-provisioner": "0.1.0"
 }

--- a/klyshko-operator/charts/klyshko-operator/CHANGELOG.md
+++ b/klyshko-operator/charts/klyshko-operator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.1](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.1.0...operator-chart-v0.1.1) (2023-03-14)
+
+
+### Bug Fixes
+
+* **mp-spdz/operator-chart:** empty commit to trigger publication of artifacts ([#30](https://github.com/carbynestack/klyshko/issues/30)) ([f9beb81](https://github.com/carbynestack/klyshko/commit/f9beb81703fe8a14f568437cd29b7362381ae402))
+
 ## [0.1.0](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.0.1...operator-chart-v0.1.0) (2023-03-13)
 
 

--- a/klyshko-operator/charts/klyshko-operator/Chart.yaml
+++ b/klyshko-operator/charts/klyshko-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: klyshko-operator
 description: A Helm chart for the Carbyne Stack Klyshko Operator
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.1](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.1.0...operator-chart-v0.1.1) (2023-03-14)


### Bug Fixes

* **mp-spdz/operator-chart:** empty commit to trigger publication of artifacts ([#30](https://github.com/carbynestack/klyshko/issues/30)) ([f9beb81](https://github.com/carbynestack/klyshko/commit/f9beb81703fe8a14f568437cd29b7362381ae402))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).