### PR TITLE
chore: release  operator-chart 0.1.2

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "klyshko-mp-spdz": "0.1.1",
   "klyshko-operator": "0.1.0",
-  "klyshko-operator/charts/klyshko-operator": "0.1.1",
+  "klyshko-operator/charts/klyshko-operator": "0.1.2",
   "klyshko-provisioner": "0.1.0"
 }

--- a/klyshko-operator/charts/klyshko-operator/CHANGELOG.md
+++ b/klyshko-operator/charts/klyshko-operator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.2](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.1.1...operator-chart-v0.1.2) (2023-03-15)
+
+
+### Bug Fixes
+
+* **mp-spdz/operator-chart:** trigger workflows ([#37](https://github.com/carbynestack/klyshko/issues/37)) ([1a754c3](https://github.com/carbynestack/klyshko/commit/1a754c336d4cef441b1cbcaeb4820d034c38b90e))
+
 ## [0.1.1](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.1.0...operator-chart-v0.1.1) (2023-03-14)
 
 

--- a/klyshko-operator/charts/klyshko-operator/Chart.yaml
+++ b/klyshko-operator/charts/klyshko-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: klyshko-operator
 description: A Helm chart for the Carbyne Stack Klyshko Operator
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.1.0


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.2](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.1.1...operator-chart-v0.1.2) (2023-03-15)


### Bug Fixes

* **mp-spdz/operator-chart:** trigger workflows ([#37](https://github.com/carbynestack/klyshko/issues/37)) ([1a754c3](https://github.com/carbynestack/klyshko/commit/1a754c336d4cef441b1cbcaeb4820d034c38b90e))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).