### PR TITLE
chore: release  operator-chart 0.1.3

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "klyshko-mp-spdz": "0.1.2",
   "klyshko-operator": "0.1.0",
-  "klyshko-operator/charts/klyshko-operator": "0.1.2",
+  "klyshko-operator/charts/klyshko-operator": "0.1.3",
   "klyshko-provisioner": "0.1.0"
 }

--- a/klyshko-operator/charts/klyshko-operator/CHANGELOG.md
+++ b/klyshko-operator/charts/klyshko-operator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.3](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.1.2...operator-chart-v0.1.3) (2023-03-15)
+
+
+### Bug Fixes
+
+* **mp-spdz/operator-chart:** trigger workflows ([#41](https://github.com/carbynestack/klyshko/issues/41)) ([bf8b9b0](https://github.com/carbynestack/klyshko/commit/bf8b9b0a51d85473d6bf785dfd0efab608124ccc))
+
 ## [0.1.2](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.1.1...operator-chart-v0.1.2) (2023-03-15)
 
 

--- a/klyshko-operator/charts/klyshko-operator/Chart.yaml
+++ b/klyshko-operator/charts/klyshko-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: klyshko-operator
 description: A Helm chart for the Carbyne Stack Klyshko Operator
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.1.0


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.3](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.1.2...operator-chart-v0.1.3) (2023-03-15)


### Bug Fixes

* **mp-spdz/operator-chart:** trigger workflows ([#41](https://github.com/carbynestack/klyshko/issues/41)) ([bf8b9b0](https://github.com/carbynestack/klyshko/commit/bf8b9b0a51d85473d6bf785dfd0efab608124ccc))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).