### PR TITLE
chore: release  operator-chart 0.1.4

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "klyshko-mp-spdz": "0.1.4",
   "klyshko-operator": "0.1.0",
-  "klyshko-operator/charts/klyshko-operator": "0.1.3",
+  "klyshko-operator/charts/klyshko-operator": "0.1.4",
   "klyshko-provisioner": "0.1.0"
 }

--- a/klyshko-operator/charts/klyshko-operator/CHANGELOG.md
+++ b/klyshko-operator/charts/klyshko-operator/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.1.4](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.1.3...operator-chart-v0.1.4) (2023-03-15)
+
+
+### Bug Fixes
+
+* **mp-spdz:** trigger workflow ([5ab6139](https://github.com/carbynestack/klyshko/commit/5ab6139349bc6349045128edde210f7d337de47d))
+* **operator-chart:** rename chart to make publication workflow work ([#47](https://github.com/carbynestack/klyshko/issues/47)) ([b529207](https://github.com/carbynestack/klyshko/commit/b5292070fda11633f8b61b972dce4882a6e7bef1))


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.4](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.1.3...operator-chart-v0.1.4) (2023-03-15)


### Bug Fixes

* **mp-spdz:** trigger workflow ([5ab6139](https://github.com/carbynestack/klyshko/commit/5ab6139349bc6349045128edde210f7d337de47d))
* **operator-chart:** rename chart to make publication workflow work ([#47](https://github.com/carbynestack/klyshko/issues/47)) ([b529207](https://github.com/carbynestack/klyshko/commit/b5292070fda11633f8b61b972dce4882a6e7bef1))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).