### PR TITLE
chore: release  operator-chart 0.1.5

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "klyshko-mp-spdz": "0.1.4",
   "klyshko-operator": "0.1.0",
-  "klyshko-operator/charts/klyshko-operator": "0.1.4",
+  "klyshko-operator/charts/klyshko-operator": "0.1.5",
   "klyshko-provisioner": "0.1.0"
 }

--- a/klyshko-operator/charts/klyshko-operator/CHANGELOG.md
+++ b/klyshko-operator/charts/klyshko-operator/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## [0.1.5](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.1.4...operator-chart-v0.1.5) (2023-03-20)
+
+
+### Bug Fixes
+
+* **operator-chart:** remove legacy chart folder incl. migration of changelog updates ([cf5b0f6](https://github.com/carbynestack/klyshko/commit/cf5b0f67e6a3e5ca2a6525e4b65b511a976d8419))
+* **operator:** enable processing of historical / missed etcd-backed roster updates ([#49](https://github.com/carbynestack/klyshko/issues/49)) ([cf5b0f6](https://github.com/carbynestack/klyshko/commit/cf5b0f67e6a3e5ca2a6525e4b65b511a976d8419)), closes [#15](https://github.com/carbynestack/klyshko/issues/15)
+* **operator:** get rid of unsupported trace logging level ([cf5b0f6](https://github.com/carbynestack/klyshko/commit/cf5b0f67e6a3e5ca2a6525e4b65b511a976d8419))
+* **operator:** use numeric user and group ID in operator dockerfile ([cf5b0f6](https://github.com/carbynestack/klyshko/commit/cf5b0f67e6a3e5ca2a6525e4b65b511a976d8419))
+* **operator:** use retries to address race condition on etcd roster updates ([cf5b0f6](https://github.com/carbynestack/klyshko/commit/cf5b0f67e6a3e5ca2a6525e4b65b511a976d8419))


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.5](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.1.4...operator-chart-v0.1.5) (2023-03-20)


### Bug Fixes

* **operator-chart:** remove legacy chart folder incl. migration of changelog updates ([cf5b0f6](https://github.com/carbynestack/klyshko/commit/cf5b0f67e6a3e5ca2a6525e4b65b511a976d8419))
* **operator:** enable processing of historical / missed etcd-backed roster updates ([#49](https://github.com/carbynestack/klyshko/issues/49)) ([cf5b0f6](https://github.com/carbynestack/klyshko/commit/cf5b0f67e6a3e5ca2a6525e4b65b511a976d8419)), closes [#15](https://github.com/carbynestack/klyshko/issues/15)
* **operator:** get rid of unsupported trace logging level ([cf5b0f6](https://github.com/carbynestack/klyshko/commit/cf5b0f67e6a3e5ca2a6525e4b65b511a976d8419))
* **operator:** use numeric user and group ID in operator dockerfile ([cf5b0f6](https://github.com/carbynestack/klyshko/commit/cf5b0f67e6a3e5ca2a6525e4b65b511a976d8419))
* **operator:** use retries to address race condition on etcd roster updates ([cf5b0f6](https://github.com/carbynestack/klyshko/commit/cf5b0f67e6a3e5ca2a6525e4b65b511a976d8419))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).