### PR TITLE
chore: release  operator-chart 0.1.7

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "klyshko-mp-spdz": "0.2.0",
   "klyshko-operator": "0.2.0",
-  "klyshko-operator/charts/klyshko": "0.1.6",
+  "klyshko-operator/charts/klyshko": "0.1.7",
   "klyshko-provisioner": "0.1.0"
 }

--- a/klyshko-operator/charts/klyshko/CHANGELOG.md
+++ b/klyshko-operator/charts/klyshko/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.7](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.1.6...operator-chart-v0.1.7) (2023-04-17)
+
+
+### Bug Fixes
+
+* **operator-chart:** add property definition for generated tuples per job ([f711469](https://github.com/carbynestack/klyshko/commit/f711469ff118e4508f16657456a6b6ed60667c61))
+
 ## [0.1.6](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.1.5...operator-chart-v0.1.6) (2023-03-22)
 
 

--- a/klyshko-operator/charts/klyshko/Chart.yaml
+++ b/klyshko-operator/charts/klyshko/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: klyshko
 description: A Helm chart for the Carbyne Stack Klyshko Operator
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: 0.1.0


### PR DESCRIPTION
:package: Staging a new release
---


## [0.1.7](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.1.6...operator-chart-v0.1.7) (2023-04-17)


### Bug Fixes

* **operator-chart:** add property definition for generated tuples per job ([f711469](https://github.com/carbynestack/klyshko/commit/f711469ff118e4508f16657456a6b6ed60667c61))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).