### PR TITLE
chore: release  operator-chart 0.2.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "klyshko-mp-spdz": "0.2.0",
   "klyshko-operator": "0.2.0",
-  "klyshko-operator/charts/klyshko": "0.1.7",
+  "klyshko-operator/charts/klyshko": "0.2.0",
   "klyshko-provisioner": "0.1.0"
 }

--- a/klyshko-operator/charts/klyshko/CHANGELOG.md
+++ b/klyshko-operator/charts/klyshko/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.0](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.1.7...operator-chart-v0.2.0) (2023-06-23)
+
+
+### Features
+
+* **operator-chart:** Add etcd endpoint configuration value ([#66](https://github.com/carbynestack/klyshko/issues/66)) ([5c065fe](https://github.com/carbynestack/klyshko/commit/5c065fe59bfded1e2d348e36ec9c46ed9eea51b4))
+
 ## [0.1.7](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.1.6...operator-chart-v0.1.7) (2023-04-17)
 
 

--- a/klyshko-operator/charts/klyshko/Chart.yaml
+++ b/klyshko-operator/charts/klyshko/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: klyshko
 description: A Helm chart for the Carbyne Stack Klyshko Operator
 type: application
-version: 0.1.7
+version: 0.2.0
 appVersion: 0.1.0


### PR DESCRIPTION
:package: Staging a new release
---


## [0.2.0](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.1.7...operator-chart-v0.2.0) (2023-06-23)


### Features

* **operator-chart:** Add etcd endpoint configuration value ([#66](https://github.com/carbynestack/klyshko/issues/66)) ([5c065fe](https://github.com/carbynestack/klyshko/commit/5c065fe59bfded1e2d348e36ec9c46ed9eea51b4))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).