### PR TITLE
chore: release  mp-spdz-cowgear 0.2.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "klyshko-mp-spdz": "0.2.0",
-  "klyshko-mp-spdz-cowgear": "0.1.0",
+  "klyshko-mp-spdz-cowgear": "0.2.0",
   "klyshko-operator": "0.2.0",
   "klyshko-operator/charts/klyshko": "0.2.0",
   "klyshko-provisioner": "0.1.0"

--- a/klyshko-mp-spdz-cowgear/CHANGELOG.md
+++ b/klyshko-mp-spdz-cowgear/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## [0.2.0](https://github.com/carbynestack/klyshko/compare/mp-spdz-cowgear-v0.1.0...mp-spdz-cowgear-v0.2.0) (2023-08-03)
+
+
+### ⚠ BREAKING CHANGES
+
+* **operator/operator-chart/mp-spdz-cowgear:** add support for inter-CRG networking and CowGear CRG ([#65](https://github.com/carbynestack/klyshko/issues/65))
+
+### Features
+
+* **operator/operator-chart/mp-spdz-cowgear:** add support for inter-CRG networking and CowGear CRG ([#65](https://github.com/carbynestack/klyshko/issues/65)) ([e356440](https://github.com/carbynestack/klyshko/commit/e356440f8b9bd5a7452ae0b9476e101bfc6926bc))
+
+
+### Bug Fixes
+
+* **mp-spdz/operator-chart:** empty commit to trigger publication of artifacts ([#30](https://github.com/carbynestack/klyshko/issues/30)) ([f9beb81](https://github.com/carbynestack/klyshko/commit/f9beb81703fe8a14f568437cd29b7362381ae402))
+* **mp-spdz/operator-chart:** trigger workflows ([#37](https://github.com/carbynestack/klyshko/issues/37)) ([1a754c3](https://github.com/carbynestack/klyshko/commit/1a754c336d4cef441b1cbcaeb4820d034c38b90e))
+* **mp-spdz/operator-chart:** trigger workflows ([#41](https://github.com/carbynestack/klyshko/issues/41)) ([bf8b9b0](https://github.com/carbynestack/klyshko/commit/bf8b9b0a51d85473d6bf785dfd0efab608124ccc))
+* **mp-spdz:** trigger workflow ([5ab6139](https://github.com/carbynestack/klyshko/commit/5ab6139349bc6349045128edde210f7d337de47d))


### PR DESCRIPTION
:package: Staging a new release
---


## [0.2.0](https://github.com/carbynestack/klyshko/compare/mp-spdz-cowgear-v0.1.0...mp-spdz-cowgear-v0.2.0) (2023-08-03)


### ⚠ BREAKING CHANGES

* **operator/operator-chart/mp-spdz-cowgear:** add support for inter-CRG networking and CowGear CRG ([#65](https://github.com/carbynestack/klyshko/issues/65))

### Features

* **operator/operator-chart/mp-spdz-cowgear:** add support for inter-CRG networking and CowGear CRG ([#65](https://github.com/carbynestack/klyshko/issues/65)) ([e356440](https://github.com/carbynestack/klyshko/commit/e356440f8b9bd5a7452ae0b9476e101bfc6926bc))


### Bug Fixes

* **mp-spdz/operator-chart:** empty commit to trigger publication of artifacts ([#30](https://github.com/carbynestack/klyshko/issues/30)) ([f9beb81](https://github.com/carbynestack/klyshko/commit/f9beb81703fe8a14f568437cd29b7362381ae402))
* **mp-spdz/operator-chart:** trigger workflows ([#37](https://github.com/carbynestack/klyshko/issues/37)) ([1a754c3](https://github.com/carbynestack/klyshko/commit/1a754c336d4cef441b1cbcaeb4820d034c38b90e))
* **mp-spdz/operator-chart:** trigger workflows ([#41](https://github.com/carbynestack/klyshko/issues/41)) ([bf8b9b0](https://github.com/carbynestack/klyshko/commit/bf8b9b0a51d85473d6bf785dfd0efab608124ccc))
* **mp-spdz:** trigger workflow ([5ab6139](https://github.com/carbynestack/klyshko/commit/5ab6139349bc6349045128edde210f7d337de47d))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).