### PR TITLE
feat: prevent Tasks in terminal state from leaking PVCs

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -9,6 +9,10 @@ file in the Carbyne Stack
 
 > **NOTE**: Please keep the following list of contributors sorted.
 
+### Resolve.tech
+
+- Adrián Vaca Humanes [adrian.humanes@vml.com](mailto:adrian.humanes@vml.com)
+
 ### Robert Bosch GmbH
 
 - Becker Sebastian

--- a/klyshko-operator/controllers/tuplegenerationtask_controller.go
+++ b/klyshko-operator/controllers/tuplegenerationtask_controller.go
@@ -380,16 +380,15 @@ func (r *TupleGenerationTaskReconciler) deletePVC(ctx context.Context, key *Rost
 	found := &v1.PersistentVolumeClaim{}
 	err := r.Get(ctx, name, found)
 	if err != nil {
-		return fmt.Errorf("persistent volume claim deletion failed for task %v: %w", key, err)
+		return fmt.Errorf("to be deleted persistent volume claim not found for task %v: %w", key, err)
 	}
-	logger.V(logging.DEBUG).Info("Persistent Volume Claim already exists")
 
 	err = r.Delete(ctx, found)
 	if err != nil {
 		return fmt.Errorf("persistent volume claim deletion failed for task %v: %w", key, err)
 	}
 
-	logger.V(logging.DEBUG).Info("Deleted Persistent Volume Claim for task %v", key)
+	logger.V(logging.DEBUG).Info("Deleted Persistent Volume Claim for task")
 	return nil
 }
 

--- a/klyshko-operator/controllers/tuplegenerationtask_controller.go
+++ b/klyshko-operator/controllers/tuplegenerationtask_controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022-2023 - for information on the respective copyright owner
+Copyright (c) 2022-2024 - for information on the respective copyright owner
 see the NOTICE file and/or the repository https://github.com/carbynestack/klyshko.
 
 SPDX-License-Identifier: Apache-2.0
@@ -60,7 +60,7 @@ func (r *TupleGenerationTaskReconciler) Reconcile(ctx context.Context, req ctrl.
 	logger := log.FromContext(ctx).WithValues("Task.Name", req.Name)
 	logger.V(logging.DEBUG).Info("Reconciling tuple generation task")
 
-	taskKey, err := r.taskKeyFromName(req.Namespace, req.Name)
+	taskKey, err := taskKeyFromName(req.Namespace, req.Name)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get key for task %v: %w", req.Name, err)
 	}
@@ -255,7 +255,7 @@ func (r *TupleGenerationTaskReconciler) SetupWithManager(mgr ctrl.Manager) error
 
 // taskKeyFromName creates a RosterEntryKey from the given name and namespace. Expects that the zero-based VCP
 // identifier is appended with a hyphen to the name.
-func (r *TupleGenerationTaskReconciler) taskKeyFromName(namespace string, name string) (*RosterEntryKey, error) {
+func taskKeyFromName(namespace string, name string) (*RosterEntryKey, error) {
 	parts := strings.Split(name, "-")
 	vcpID := parts[len(parts)-1]
 	jobName := strings.Join(parts[:len(parts)-1], "-")


### PR DESCRIPTION
Running in EKS and GKE with otherwise default storage configuration, we have observed leaked PVCs. This change ought to prevent that from happening by eagerly deleting them.