### PR TITLE
chore: release  operator 0.3.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
   "klyshko-mp-spdz": "0.2.0",
   "klyshko-mp-spdz-cowgear": "0.2.0",
-  "klyshko-operator": "0.3.0",
+  "klyshko-operator": "0.3.1",
   "klyshko-operator/charts/klyshko": "0.4.0",
   "klyshko-provisioner": "0.1.1"
 }

--- a/klyshko-operator/CHANGELOG.md
+++ b/klyshko-operator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.1](https://github.com/carbynestack/klyshko/compare/operator-v0.3.0...operator-v0.3.1) (2024-10-31)
+
+
+### Bug Fixes
+
+* **operator:** pin setup-envtest version ([#94](https://github.com/carbynestack/klyshko/issues/94)) ([b46b543](https://github.com/carbynestack/klyshko/commit/b46b543b654917f8067050948caa42c1121410b7))
+* **operator:** prevent Tasks in terminal state from leaking PVCs ([#93](https://github.com/carbynestack/klyshko/issues/93)) ([6029adf](https://github.com/carbynestack/klyshko/commit/6029adf16f90a06a30dc55da452682315c7250ef))
+
 ## [0.3.0](https://github.com/carbynestack/klyshko/compare/operator-v0.2.0...operator-v0.3.0) (2023-08-03)
 
 


### PR DESCRIPTION
:package: Staging a new release
---


## [0.3.1](https://github.com/carbynestack/klyshko/compare/operator-v0.3.0...operator-v0.3.1) (2024-10-31)


### Bug Fixes

* **operator:** pin setup-envtest version ([#94](https://github.com/carbynestack/klyshko/issues/94)) ([b46b543](https://github.com/carbynestack/klyshko/commit/b46b543b654917f8067050948caa42c1121410b7))
* **operator:** prevent Tasks in terminal state from leaking PVCs ([#93](https://github.com/carbynestack/klyshko/issues/93)) ([6029adf](https://github.com/carbynestack/klyshko/commit/6029adf16f90a06a30dc55da452682315c7250ef))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).