### PR TITLE
chore: release  operator 0.4.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
   "klyshko-mp-spdz": "0.2.0",
   "klyshko-mp-spdz-cowgear": "0.2.0",
-  "klyshko-operator": "0.3.1",
+  "klyshko-operator": "0.4.0",
   "klyshko-operator/charts/klyshko": "0.4.0",
   "klyshko-provisioner": "0.1.1"
 }

--- a/klyshko-operator/CHANGELOG.md
+++ b/klyshko-operator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.4.0](https://github.com/carbynestack/klyshko/compare/operator-v0.3.1...operator-v0.4.0) (2026-03-26)
+
+
+### Features
+
+* add SGX/Gramine TEE support for CRG ([#98](https://github.com/carbynestack/klyshko/issues/98)) ([12c1866](https://github.com/carbynestack/klyshko/commit/12c1866b0b935fa18bc2ed7d603a25bec798390e))
+
 ## [0.3.1](https://github.com/carbynestack/klyshko/compare/operator-v0.3.0...operator-v0.3.1) (2024-10-31)
 
 


### PR DESCRIPTION
:package: Staging a new release
---


## [0.4.0](https://github.com/carbynestack/klyshko/compare/operator-v0.3.1...operator-v0.4.0) (2026-03-26)


### Features

* add SGX/Gramine TEE support for CRG ([#98](https://github.com/carbynestack/klyshko/issues/98)) ([12c1866](https://github.com/carbynestack/klyshko/commit/12c1866b0b935fa18bc2ed7d603a25bec798390e))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).