### PR TITLE
chore: release  operator-chart 0.5.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,6 +2,6 @@
   "klyshko-mp-spdz": "0.2.0",
   "klyshko-mp-spdz-cowgear": "0.2.0",
   "klyshko-operator": "0.4.0",
-  "klyshko-operator/charts/klyshko": "0.4.0",
+  "klyshko-operator/charts/klyshko": "0.5.0",
   "klyshko-provisioner": "0.1.1"
 }

--- a/klyshko-operator/charts/klyshko/CHANGELOG.md
+++ b/klyshko-operator/charts/klyshko/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.0](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.4.0...operator-chart-v0.5.0) (2026-04-07)
+
+
+### Features
+
+* add SGX/Gramine TEE support for CRG ([#98](https://github.com/carbynestack/klyshko/issues/98)) ([12c1866](https://github.com/carbynestack/klyshko/commit/12c1866b0b935fa18bc2ed7d603a25bec798390e))
+
 ## [0.4.0](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.3.0...operator-chart-v0.4.0) (2023-09-04)
 
 

--- a/klyshko-operator/charts/klyshko/Chart.yaml
+++ b/klyshko-operator/charts/klyshko/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: klyshko
 description: A Helm chart for the Carbyne Stack Klyshko Operator
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: 0.3.0


### PR DESCRIPTION
:package: Staging a new release
---


## [0.5.0](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.4.0...operator-chart-v0.5.0) (2026-04-07)


### Features

* add SGX/Gramine TEE support for CRG ([#98](https://github.com/carbynestack/klyshko/issues/98)) ([12c1866](https://github.com/carbynestack/klyshko/commit/12c1866b0b935fa18bc2ed7d603a25bec798390e))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).