### PR TITLE
fix(operator-chart): use quay.io mirror for kube-rbac-proxy

### DIFF
--- a/klyshko-operator/charts/klyshko/templates/deployment.yaml
+++ b/klyshko-operator/charts/klyshko/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=10
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+          image: quay.io/brancz/kube-rbac-proxy:v0.8.0
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/klyshko-operator/config/default/manager_auth_proxy_patch.yaml
+++ b/klyshko-operator/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
gcr.io/kubebuilder/kube-rbac-proxy was removed and image pulls fail; quay.io/brancz/kube-rbac-proxy:v0.8.0 is a confirmed working replacement.