### PR TITLE
fix: temporary resolve CI test failures by modernizing build infrastructure

### DIFF
--- a/.github/workflows/operator.build-and-test.yaml
+++ b/.github/workflows/operator.build-and-test.yaml
@@ -40,9 +40,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version-file: ${{ env.WORKING_DIRECTORY }}/go.mod
+          go-version: '1.22'
           cache-dependency-path: ${{ env.WORKING_DIRECTORY }}/go.sum
       - name: Build and Test
         working-directory: ${{ env.WORKING_DIRECTORY }}

--- a/klyshko-operator/Makefile
+++ b/klyshko-operator/Makefile
@@ -40,9 +40,9 @@ BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 # Image URL to use all building/pushing image targets
 IMG ?= klyshko-operator-controller:v$(VERSION)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
+CRD_OPTIONS ?= "crd"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.21
+ENVTEST_K8S_VERSION = 1.25.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -52,8 +52,6 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
-# This is a requirement for 'setup-envtest.sh' in the test target.
-# Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
@@ -89,8 +87,13 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+# Define the local binary location
+ENVTEST = $(shell pwd)/bin/setup-envtest
+
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" GINKGO_EDITOR_INTEGRATION=true go test -v ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$$( $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(shell pwd)/bin -p path )" \
+	GINKGO_EDITOR_INTEGRATION=true \
+	go test -v ./... -coverprofile cover.out
 
 ##@ Build
 
@@ -121,49 +124,41 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=true -f -
 
-
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.1)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0)
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
 	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
 
-ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230216140739-c98506dc3b8e)
+	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.20)
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
+# Modernized macro using go install instead of legacy go get execution paths
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
 @[ -f $(1) ] || { \
 set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
-rm -rf $$TMP_DIR ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 }
 endef
 
-.PHONY: bundle
+.PHONY: bundle bundle-build bundle-push opm catalog-build catalog-push
+
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	operator-sdk bundle validate ./bundle
 
-.PHONY: bundle-build
 bundle-build: ## Build the bundle image.
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
-.PHONY: bundle-push
 bundle-push: ## Push the bundle image.
 	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
 
-.PHONY: opm
 OPM = ./bin/opm
 opm: ## Download opm locally if necessary.
 ifeq (,$(wildcard $(OPM)))
@@ -195,11 +190,9 @@ endif
 # Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
 # This recipe invokes 'opm' in 'semver' bundle add mode. For more information on add modes, see:
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
-.PHONY: catalog-build
 catalog-build: opm ## Build a catalog image.
 	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 # Push the catalog image.
-.PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)


### PR DESCRIPTION
## Problem
The `operator.build-and-test` workflow has been failing due to the deprecation of the legacy GCS bucket as mentioned in issue #99 

## Solution
This PR temporarily resolves the CI pipeline failures by upgrading the build toolchain. It upgrades the Go environment used by the GitHub Actions runner and updates the build dependencies (`controller-gen` and `setup-envtest`) to versions that are compatible with current Kubernetes infrastructure.

*Note: This PR updates the Go environment used for build and test tooling only. It does not change the Go version required by the application code in `go.mod`.*

## Changes

*   **Updated CI Toolchain:** Updated the GitHub Actions runner to use Go 1.22+ to satisfy the runtime requirements of modern build tools.
*   **Upgraded `controller-gen`:** Updated from `v0.6.1` to `v0.14.0`. This was necessary to resolve `SIGSEGV` panics triggered by incompatibilities between the older toolchain and the newer Go compiler structure.
*   **Infrastructure Fix:** Updated `setup-envtest` to use `@release-0.20`. This routes download requests to the supported index hosted on GitHub/Controller-Tools, bypassing the deprecated GCS bucket entirely.
*   **Manifest Generation:** Simplified `CRD_OPTIONS` in the `Makefile` to reflect modern standard defaults, removing deprecated flags that are no longer supported.

## Verification

*   **CI Pipeline:** Verified the `operator.build-and-test` workflow now passes on a clean GitHub Actions runner.