### PR TITLE
chore: release  operator-chart 0.5.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,6 +2,6 @@
   "klyshko-mp-spdz": "0.2.0",
   "klyshko-mp-spdz-cowgear": "0.2.0",
   "klyshko-operator": "0.4.0",
-  "klyshko-operator/charts/klyshko": "0.5.0",
+  "klyshko-operator/charts/klyshko": "0.5.1",
   "klyshko-provisioner": "0.1.1"
 }

--- a/klyshko-operator/charts/klyshko/CHANGELOG.md
+++ b/klyshko-operator/charts/klyshko/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.1](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.5.0...operator-chart-v0.5.1) (2026-07-31)
+
+
+### Bug Fixes
+
+* **operator-chart:** use quay.io mirror for kube-rbac-proxy (carbynestack[#123](https://github.com/carbynestack/klyshko/issues/123)) ([#104](https://github.com/carbynestack/klyshko/issues/104)) ([548da55](https://github.com/carbynestack/klyshko/commit/548da555998cd154869dc356adcbb94a1d579fdd))
+
 ## [0.5.0](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.4.0...operator-chart-v0.5.0) (2026-04-07)
 
 

--- a/klyshko-operator/charts/klyshko/Chart.yaml
+++ b/klyshko-operator/charts/klyshko/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: klyshko
 description: A Helm chart for the Carbyne Stack Klyshko Operator
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: 0.3.0


### PR DESCRIPTION
:package: Staging a new release
---


## [0.5.1](https://github.com/carbynestack/klyshko/compare/operator-chart-v0.5.0...operator-chart-v0.5.1) (2026-07-31)


### Bug Fixes

* **operator-chart:** use quay.io mirror for kube-rbac-proxy (carbynestack[#123](https://github.com/carbynestack/klyshko/issues/123)) ([#104](https://github.com/carbynestack/klyshko/issues/104)) ([548da55](https://github.com/carbynestack/klyshko/commit/548da555998cd154869dc356adcbb94a1d579fdd))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).